### PR TITLE
Prevent google-sign-in 6.0.0 ios sdk

### DIFF
--- a/GoogleSignInPlugin/Assets/GoogleSignIn/Editor/GoogleSignInDependencies.xml
+++ b/GoogleSignInPlugin/Assets/GoogleSignIn/Editor/GoogleSignInDependencies.xml
@@ -12,7 +12,7 @@
 
   <!-- iOS Cocoapod dependencies can be specified by each iosPod element. -->
   <iosPods>
-    <iosPod name="GoogleSignIn" version=">= 5.0.0" bitcodeEnabled="false"
+    <iosPod name="GoogleSignIn" version="= 5.0.2" bitcodeEnabled="false"
         minTargetSdk="6.0">
     </iosPod>
   </iosPods>


### PR DESCRIPTION
Google sign in iOS sdk received some breaking changes to the API in 6.0.0
https://developers.google.com/identity/sign-in/ios/release